### PR TITLE
Camera packet instead of TP & NPC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,5 +25,4 @@ repositories {
 dependencies {
     compileOnly 'org.spigotmc:spigot-api:1.18.2-R0.1-SNAPSHOT'
     compileOnly 'com.mojang:authlib:3.3.39'
-    compileOnly files('../nms-1.18.2.jar')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,1 @@
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip

--- a/src/main/java/io/github/tanguygab/cctv/CCTV.java
+++ b/src/main/java/io/github/tanguygab/cctv/CCTV.java
@@ -16,6 +16,7 @@ import io.github.tanguygab.cctv.managers.ViewerManager;
 import io.github.tanguygab.cctv.menus.CCTVMenu;
 import io.github.tanguygab.cctv.utils.CustomHeads;
 import io.github.tanguygab.cctv.utils.Heads;
+import io.github.tanguygab.cctv.utils.NMSUtils;
 import io.github.tanguygab.cctv.utils.Utils;
 import org.bukkit.*;
 import org.bukkit.command.Command;
@@ -38,6 +39,7 @@ public class CCTV extends JavaPlugin {
     private ConfigurationFile config;
     private LanguageFile lang;
     private CustomHeads customHeads;
+    private NMSUtils nms;
     public ConfigurationFile getConfiguration() {
         return config;
     }
@@ -46,6 +48,9 @@ public class CCTV extends JavaPlugin {
     }
     public CustomHeads getCustomHeads() {
         return customHeads;
+    }
+    public NMSUtils getNMS() {
+        return nms;
     }
 
     private CameraCmd cameraCmd;
@@ -85,6 +90,7 @@ public class CCTV extends JavaPlugin {
         }
 
         customHeads = new CustomHeads();
+        nms = new NMSUtils();
 
         cameraCmd = new CameraCmd();
         groupCmd = new GroupCmd();

--- a/src/main/java/io/github/tanguygab/cctv/CCTV.java
+++ b/src/main/java/io/github/tanguygab/cctv/CCTV.java
@@ -16,12 +16,10 @@ import io.github.tanguygab.cctv.managers.ViewerManager;
 import io.github.tanguygab.cctv.menus.CCTVMenu;
 import io.github.tanguygab.cctv.utils.CustomHeads;
 import io.github.tanguygab.cctv.utils.Heads;
-import io.github.tanguygab.cctv.utils.NMSUtils;
 import io.github.tanguygab.cctv.utils.Utils;
 import org.bukkit.*;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ShapedRecipe;
@@ -183,21 +181,6 @@ public class CCTV extends JavaPlugin {
                 onDisable();
                 onEnable();
                 sender.sendMessage("Plugin reloaded!");
-            }
-            case "test" -> {
-                if (sender instanceof Player p) {
-                    if (!cam) {
-                        p.sendMessage("cam armor stand");
-                        ArmorStand as = cameraManager.get(args[1]).getArmorStand();
-                        NMSUtils.setCameraPacket(p,as);
-                        cam = true;
-                        return true;
-                    }
-                    p.sendMessage("cam player");
-                    NMSUtils.setCameraPacket(p,p);
-                    cam = false;
-
-                }
             }
             default -> sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
                     "&6&m                                        \n"

--- a/src/main/java/io/github/tanguygab/cctv/CCTV.java
+++ b/src/main/java/io/github/tanguygab/cctv/CCTV.java
@@ -16,10 +16,12 @@ import io.github.tanguygab.cctv.managers.ViewerManager;
 import io.github.tanguygab.cctv.menus.CCTVMenu;
 import io.github.tanguygab.cctv.utils.CustomHeads;
 import io.github.tanguygab.cctv.utils.Heads;
+import io.github.tanguygab.cctv.utils.NMSUtils;
 import io.github.tanguygab.cctv.utils.Utils;
 import org.bukkit.*;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ShapedRecipe;
@@ -129,7 +131,7 @@ public class CCTV extends JavaPlugin {
             cameraManager.unviewCamera(p);
             p.closeInventory();
         }
-        getLogger().info("CCTV Plugin has been succesfully Disabled!");
+        getLogger().info("CCTV Plugin has been successfully Disabled!");
     }
 
     private void loadRecipes() {
@@ -164,6 +166,8 @@ public class CCTV extends JavaPlugin {
         menu.open();
     }
 
+    private boolean cam = false;
+
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         String arg = args.length > 0 ? args[0] : "";
@@ -179,6 +183,21 @@ public class CCTV extends JavaPlugin {
                 onDisable();
                 onEnable();
                 sender.sendMessage("Plugin reloaded!");
+            }
+            case "test" -> {
+                if (sender instanceof Player p) {
+                    if (!cam) {
+                        p.sendMessage("cam armor stand");
+                        ArmorStand as = cameraManager.get(args[1]).getArmorStand();
+                        NMSUtils.setCameraPacket(p,as);
+                        cam = true;
+                        return true;
+                    }
+                    p.sendMessage("cam player");
+                    NMSUtils.setCameraPacket(p,p);
+                    cam = false;
+
+                }
             }
             default -> sender.sendMessage(ChatColor.translateAlternateColorCodes('&',
                     "&6&m                                        \n"

--- a/src/main/java/io/github/tanguygab/cctv/CCTV.java
+++ b/src/main/java/io/github/tanguygab/cctv/CCTV.java
@@ -130,11 +130,8 @@ public class CCTV extends JavaPlugin {
         HandlerList.unregisterAll(this);
 
         cameraManager.unload();
-
-        for (Player p : Bukkit.getOnlinePlayers()) {
-            cameraManager.unviewCamera(p);
-            p.closeInventory();
-        }
+        viewerManager.unload();
+        Listener.openedMenus.forEach((p,inv)->p.closeInventory());
         getLogger().info("CCTV Plugin has been successfully Disabled!");
     }
 

--- a/src/main/java/io/github/tanguygab/cctv/commands/CameraCmd.java
+++ b/src/main/java/io/github/tanguygab/cctv/commands/CameraCmd.java
@@ -134,7 +134,7 @@ public class CameraCmd extends Command {
                     p.sendMessage(lang.CAMERA_NOT_FOUND);
                     return;
                 }
-                cm.teleport(camera,p);
+                p.teleport(camera.getArmorStand());
             }
             case "enable" -> {
                 if (noPerm(p, "enable")) {

--- a/src/main/java/io/github/tanguygab/cctv/entities/Camera.java
+++ b/src/main/java/io/github/tanguygab/cctv/entities/Camera.java
@@ -5,6 +5,8 @@ import io.github.tanguygab.cctv.config.LanguageFile;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.util.EulerAngle;
 
@@ -18,11 +20,13 @@ public class Camera extends ID {
     private boolean shown;
     private String skin;
     private ArmorStand armorStand;
+    private Creeper creeper;
 
-    public Camera(String name, String owner, Location loc, boolean enabled, boolean shown, ArmorStand armorStand, String skin) {
+    public Camera(String name, String owner, Location loc, boolean enabled, boolean shown, ArmorStand armorStand, Creeper creeper, String skin) {
         super(name,CCTV.get().getCameras());
         setOwner(owner);
         this.armorStand = armorStand;
+        this.creeper = creeper;
         setLocation(loc);
         setEnabled(enabled);
         setShown(shown);
@@ -72,14 +76,9 @@ public class Camera extends ID {
         set("yaw", loc.getYaw());
         armorStand.teleport(loc);
         armorStand.setHeadPose(new EulerAngle(Math.toRadians(loc.getPitch()), 0.0D, 0.0D));
-        tpViewers();
-    }
-    private void tpViewers() {
-        for (Viewer viewer : CCTV.get().getViewers().values()) {
-            if (viewer.getCamera() != this) continue;
-            Player target = Bukkit.getServer().getPlayer(UUID.fromString(viewer.getId()));
-            if (target != null) CCTV.get().getCameras().teleport(this, target);
-        }
+        loc.add(0,0.5,0);
+        creeper.teleport(loc);
+        loc.add(0,-0.5,0);
     }
 
     public boolean rotateHorizontally(int degrees) {
@@ -93,7 +92,9 @@ public class Camera extends ID {
         if (newYaw < Math.round(check-36.0F) || newYaw > Math.round(check+36.0F)) return false;
         asLoc.setYaw(newYaw);
         armorStand.teleport(asLoc);
-        tpViewers();
+        loc.add(0,0.5,0);
+        creeper.teleport(loc);
+        loc.add(0,-0.5,0);
         return true;
     }
     public boolean rotateVertically(int degrees) {
@@ -138,9 +139,8 @@ public class Camera extends ID {
     public ArmorStand getArmorStand() {
         return armorStand;
     }
-
-    public void setArmorStand(ArmorStand armorStand) {
-        this.armorStand = armorStand;
+    public Creeper getCreeper() {
+        return creeper;
     }
 
     public String getSkin() {
@@ -150,5 +150,21 @@ public class Camera extends ID {
         this.skin = skin;
         set("skin",skin);
         setShown(true);
+    }
+
+    public boolean is(Entity entity) {
+        if (entity instanceof Creeper c) {
+            if (creeper.getUniqueId().equals(c.getUniqueId())) {
+                if (creeper != c) creeper = c;
+                return true;
+            }
+        }
+        if (entity instanceof ArmorStand as) {
+            if (armorStand.getUniqueId().equals(as.getUniqueId())) {
+                if (armorStand != as) armorStand = as;
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/io/github/tanguygab/cctv/entities/Camera.java
+++ b/src/main/java/io/github/tanguygab/cctv/entities/Camera.java
@@ -92,9 +92,9 @@ public class Camera extends ID {
         if (newYaw < Math.round(check-36.0F) || newYaw > Math.round(check+36.0F)) return false;
         asLoc.setYaw(newYaw);
         armorStand.teleport(asLoc);
-        loc.add(0,0.5,0);
-        creeper.teleport(loc);
-        loc.add(0,-0.5,0);
+        asLoc.add(0,0.5,0);
+        creeper.teleport(asLoc);
+        asLoc.add(0,-0.5,0);
         return true;
     }
     public boolean rotateVertically(int degrees) {

--- a/src/main/java/io/github/tanguygab/cctv/entities/Viewer.java
+++ b/src/main/java/io/github/tanguygab/cctv/entities/Viewer.java
@@ -3,6 +3,8 @@ package io.github.tanguygab.cctv.entities;
 import io.github.tanguygab.cctv.CCTV;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 
 public class Viewer extends ID {
 
@@ -43,6 +45,11 @@ public class Viewer extends ID {
         this.nightVision = nightVision;
         CCTV cctv = CCTV.get();
         Player p = cctv.getViewers().get(this);
+        if (cctv.getCameras().OLD_CAMERA_VIEW) {
+            if (nightVision) p.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION,1000000,0));
+            else p.removePotionEffect(PotionEffectType.NIGHT_VISION);
+            return;
+        }
         if (nightVision) {
             p.hideEntity(cctv, camera.getArmorStand());
             cctv.getNMS().setCameraPacket(p,camera.getCreeper());
@@ -51,4 +58,5 @@ public class Viewer extends ID {
         p.showEntity(cctv, camera.getArmorStand());
         cctv.getNMS().setCameraPacket(p, camera.getArmorStand());
     }
+
 }

--- a/src/main/java/io/github/tanguygab/cctv/entities/Viewer.java
+++ b/src/main/java/io/github/tanguygab/cctv/entities/Viewer.java
@@ -1,7 +1,6 @@
 package io.github.tanguygab.cctv.entities;
 
 import io.github.tanguygab.cctv.CCTV;
-import io.github.tanguygab.cctv.utils.NMSUtils;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -42,13 +41,14 @@ public class Viewer extends ID {
     }
     public void setNightVision(boolean nightVision) {
         this.nightVision = nightVision;
-        Player p = CCTV.get().getViewers().get(this);
+        CCTV cctv = CCTV.get();
+        Player p = cctv.getViewers().get(this);
         if (nightVision) {
-            p.hideEntity(CCTV.get(), camera.getArmorStand());
-            NMSUtils.setCameraPacket(p,camera.getCreeper());
+            p.hideEntity(cctv, camera.getArmorStand());
+            cctv.getNMS().setCameraPacket(p,camera.getCreeper());
             return;
         }
-        p.showEntity(CCTV.get(), camera.getArmorStand());
-        NMSUtils.setCameraPacket(p, camera.getArmorStand());
+        p.showEntity(cctv, camera.getArmorStand());
+        cctv.getNMS().setCameraPacket(p, camera.getArmorStand());
     }
 }

--- a/src/main/java/io/github/tanguygab/cctv/entities/Viewer.java
+++ b/src/main/java/io/github/tanguygab/cctv/entities/Viewer.java
@@ -2,35 +2,25 @@ package io.github.tanguygab.cctv.entities;
 
 import io.github.tanguygab.cctv.CCTV;
 import io.github.tanguygab.cctv.utils.NMSUtils;
-import org.bukkit.GameMode;
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 public class Viewer extends ID {
 
     private final ItemStack[] inv;
-    private final GameMode gm;
     private Camera camera;
     private CameraGroup group;
-    private final Location loc;
     private boolean nightVision;
 
     public Viewer(Player p, Camera camera, CameraGroup group) {
         super(p.getUniqueId().toString(),CCTV.get().getViewers());
         inv = p.getInventory().getContents().clone();
-        gm = p.getGameMode();
         this.camera = camera;
         this.group = group;
-        loc = p.getLocation();
     }
 
     public ItemStack[] getInv() {
         return inv;
-    }
-
-    public GameMode getGameMode() {
-        return gm;
     }
 
     public Camera getCamera() {
@@ -45,10 +35,6 @@ public class Viewer extends ID {
     }
     public void setGroup(CameraGroup group) {
         this.group = group;
-    }
-
-    public Location getLoc() {
-        return loc;
     }
 
     public boolean hasNightVision() {

--- a/src/main/java/io/github/tanguygab/cctv/entities/Viewer.java
+++ b/src/main/java/io/github/tanguygab/cctv/entities/Viewer.java
@@ -1,6 +1,7 @@
 package io.github.tanguygab.cctv.entities;
 
 import io.github.tanguygab.cctv.CCTV;
+import io.github.tanguygab.cctv.utils.NMSUtils;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -12,8 +13,8 @@ public class Viewer extends ID {
     private final GameMode gm;
     private Camera camera;
     private CameraGroup group;
-    private Object npc;
     private final Location loc;
+    private boolean nightVision;
 
     public Viewer(Player p, Camera camera, CameraGroup group) {
         super(p.getUniqueId().toString(),CCTV.get().getViewers());
@@ -46,14 +47,15 @@ public class Viewer extends ID {
         this.group = group;
     }
 
-    public Object getNpc() {
-        return npc;
-    }
-    public void setNpc(Object npc) {
-        this.npc = npc;
-    }
-
     public Location getLoc() {
         return loc;
+    }
+
+    public boolean hasNightVision() {
+        return nightVision;
+    }
+    public void setNightVision(boolean nightVision) {
+        this.nightVision = nightVision;
+        NMSUtils.setCameraPacket(CCTV.get().getViewers().get(this), nightVision ? camera.getCreeper() : camera.getArmorStand());
     }
 }

--- a/src/main/java/io/github/tanguygab/cctv/entities/Viewer.java
+++ b/src/main/java/io/github/tanguygab/cctv/entities/Viewer.java
@@ -56,6 +56,13 @@ public class Viewer extends ID {
     }
     public void setNightVision(boolean nightVision) {
         this.nightVision = nightVision;
-        NMSUtils.setCameraPacket(CCTV.get().getViewers().get(this), nightVision ? camera.getCreeper() : camera.getArmorStand());
+        Player p = CCTV.get().getViewers().get(this);
+        if (nightVision) {
+            p.hideEntity(CCTV.get(), camera.getArmorStand());
+            NMSUtils.setCameraPacket(p,camera.getCreeper());
+            return;
+        }
+        p.showEntity(CCTV.get(), camera.getArmorStand());
+        NMSUtils.setCameraPacket(p, camera.getArmorStand());
     }
 }

--- a/src/main/java/io/github/tanguygab/cctv/listeners/Listener.java
+++ b/src/main/java/io/github/tanguygab/cctv/listeners/Listener.java
@@ -160,4 +160,10 @@ public class Listener implements org.bukkit.event.Listener {
         if (menu != null && menu.inv.equals(e.getInventory())) openedMenus.get(p).close();
     }
 
+    @EventHandler
+    public void on(PlayerMoveEvent e) {
+        if (vm.exists(e.getPlayer()))
+            e.setCancelled(true);
+    }
+
 }

--- a/src/main/java/io/github/tanguygab/cctv/listeners/ViewersEvents.java
+++ b/src/main/java/io/github/tanguygab/cctv/listeners/ViewersEvents.java
@@ -11,8 +11,11 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryInteractEvent;
 import org.bukkit.event.player.*;
+
+import java.util.Arrays;
 
 public class ViewersEvents implements Listener {
 
@@ -73,7 +76,19 @@ public class ViewersEvents implements Listener {
             vm.onCameraItems(p, p.getInventory().getItemInMainHand());
             e.setCancelled(true);
         }
+    }
 
-
+    @EventHandler
+    public void on(PlayerDeathEvent e) {
+        Player p = e.getEntity();
+        if (vm.exists(p)) {
+            if (!e.getKeepInventory()) {
+                e.getDrops().clear();
+                e.getDrops().addAll(Arrays.asList(vm.get(p).getInv()));
+            }
+            vm.delete(p);
+            if (!e.getKeepInventory())
+                p.getInventory().clear();
+        }
     }
 }

--- a/src/main/java/io/github/tanguygab/cctv/listeners/ViewersEvents.java
+++ b/src/main/java/io/github/tanguygab/cctv/listeners/ViewersEvents.java
@@ -33,16 +33,6 @@ public class ViewersEvents implements Listener {
     }
 
     @EventHandler
-    public void on(PlayerMoveEvent e) {
-        Player p = e.getPlayer();
-        if (!vm.exists(p)) return;
-
-        p.setAllowFlight(true);
-        p.setFlying(true);
-        cm.teleport(vm.get(p).getCamera(), p);
-    }
-
-    @EventHandler
     public void on(PlayerToggleSneakEvent e) {
         Player player = e.getPlayer();
         if (!vm.exists(player)) return;

--- a/src/main/java/io/github/tanguygab/cctv/managers/CameraManager.java
+++ b/src/main/java/io/github/tanguygab/cctv/managers/CameraManager.java
@@ -126,7 +126,7 @@ public class CameraManager extends Manager<Camera> {
 
     public void unviewCamera(Player player) {
         if (player == null) return;
-        NMSUtils.setCameraPacket(player,player);
+        cctv.getNMS().setCameraPacket(player,player);
         cctv.getViewers().delete(player);
     }
 
@@ -164,7 +164,7 @@ public class CameraManager extends Manager<Camera> {
         connecting.add(p);
         Bukkit.getScheduler().scheduleSyncDelayedTask(cctv,  () -> {
             vm.createPlayer(p, cam, group);
-            NMSUtils.setCameraPacket(p,cam.getArmorStand());
+            cctv.getNMS().setCameraPacket(p,cam.getArmorStand());
             connecting.remove(p);
         }, vm.TIME_TO_CONNECT * 20L);
     }
@@ -175,7 +175,7 @@ public class CameraManager extends Manager<Camera> {
             p.sendMessage(lang.CAMERA_NOT_FOUND);
             return;
         }
-        NMSUtils.setCameraPacket(p,cam.getArmorStand());
+        cctv.getNMS().setCameraPacket(p,cam.getArmorStand());
     }
 
     public void rotateHorizontally(Player p, Camera camera, int degrees) {

--- a/src/main/java/io/github/tanguygab/cctv/managers/CameraManager.java
+++ b/src/main/java/io/github/tanguygab/cctv/managers/CameraManager.java
@@ -1,12 +1,9 @@
 package io.github.tanguygab.cctv.managers;
 
 import io.github.tanguygab.cctv.CCTV;
-import io.github.tanguygab.cctv.config.LanguageFile;
 import io.github.tanguygab.cctv.entities.Camera;
 import io.github.tanguygab.cctv.entities.CameraGroup;
-import io.github.tanguygab.cctv.entities.Viewer;
 import io.github.tanguygab.cctv.utils.Heads;
-import io.github.tanguygab.cctv.utils.NMSUtils;
 import io.github.tanguygab.cctv.utils.Utils;
 import org.bukkit.*;
 import org.bukkit.entity.ArmorStand;
@@ -22,6 +19,7 @@ import java.util.Map;
 public class CameraManager extends Manager<Camera> {
     
     public double CAMERA_HEAD_RADIUS;
+    public boolean OLD_CAMERA_VIEW;
     public List<Player> connecting = new ArrayList<>();
 
     public CameraManager() {
@@ -31,6 +29,7 @@ public class CameraManager extends Manager<Camera> {
     @Override
     public void load() {
         CAMERA_HEAD_RADIUS = cctv.getConfiguration().getDouble("camera_head_radius",0.35D);
+        OLD_CAMERA_VIEW = cctv.getConfiguration().getBoolean("old_camera_view",false);
         
         Map<String, Object> cams = file.getValues();
         cams.forEach((id,cfg)->{
@@ -130,6 +129,7 @@ public class CameraManager extends Manager<Camera> {
 
     public void unviewCamera(Player player) {
         if (player == null) return;
+        if (!cctv.getViewers().exists(player)) return;
         cctv.getNMS().setCameraPacket(player,player);
         cctv.getViewers().delete(player);
     }
@@ -187,15 +187,27 @@ public class CameraManager extends Manager<Camera> {
             p.sendMessage(lang.NO_PERMISSIONS);
             return;
         }
-        if (!camera.rotateHorizontally(degrees))
+        if (!camera.rotateHorizontally(degrees)) {
             p.sendMessage(lang.MAX_ROTATION);
+            return;
+        }
+        if (OLD_CAMERA_VIEW) tp(p,camera);
     }
     public void rotateVertically(Player p, Camera camera, int degrees) {
         if (!p.hasPermission("cctv.view.move")) {
             p.sendMessage(lang.NO_PERMISSIONS);
             return;
         }
-        if (!camera.rotateVertically(degrees))
+        if (!camera.rotateVertically(degrees)) {
             p.sendMessage(lang.MAX_ROTATION);
+            return;
+        }
+        if (OLD_CAMERA_VIEW) tp(p,camera);
+    }
+
+    private void tp(Player p, Camera camera) {
+        Location loc = camera.getArmorStand().getLocation().clone();
+        loc.add(0,1,0);
+        p.teleport(loc);
     }
 }

--- a/src/main/java/io/github/tanguygab/cctv/managers/CameraManager.java
+++ b/src/main/java/io/github/tanguygab/cctv/managers/CameraManager.java
@@ -37,8 +37,8 @@ public class CameraManager extends Manager<Camera> {
             Map<String,Object> config = (Map<String, Object>) cfg;
             String owner = config.get("owner")+"";
             String skin = config.getOrDefault("skin","_DEFAULT_")+"";
-            boolean enabled = (boolean) config.get("enabled");
-            boolean shown = (boolean) config.get("shown");
+            boolean enabled = (boolean) config.getOrDefault("enabled",true);
+            boolean shown = (boolean) config.getOrDefault("shown",true);
 
             World world = Bukkit.getServer().getWorld(config.get("world")+"");
             double x = (double) config.get("x");
@@ -54,6 +54,10 @@ public class CameraManager extends Manager<Camera> {
                 if (entity instanceof ArmorStand as) {
                     if (as.getCustomName() != null && as.getCustomName().equals("CAM-" + id))
                         as.remove();
+                }
+                if (entity instanceof Creeper creeper) {
+                    if (creeper.getCustomName() != null && creeper.getCustomName().equals("CAM-" + id))
+                        creeper.remove();
                 }
             }
             create(id,owner,loc,enabled,shown,skin);

--- a/src/main/java/io/github/tanguygab/cctv/managers/ViewerManager.java
+++ b/src/main/java/io/github/tanguygab/cctv/managers/ViewerManager.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.UUID;
 
 public class ViewerManager extends Manager<Viewer> {
-
     public boolean CISWP;
+
     public int TIME_TO_CONNECT;
     public int TIME_TO_DISCONNECT;
     public int TIME_FOR_SPOT;
@@ -42,6 +42,10 @@ public class ViewerManager extends Manager<Viewer> {
         TIME_FOR_SPOT = config.getInt("time_for_spot",5);
     }
 
+    public void unload() {
+        values().forEach(v-> cctv.getCameras().unviewCamera(get(v)));
+    }
+
     @Override
     public void delete(String id, Player player) {
         Viewer viewer = get(id);
@@ -56,11 +60,11 @@ public class ViewerManager extends Manager<Viewer> {
         p.setCanPickupItems(true);
         delete(id);
     }
-
     public void delete(Player p) {delete(p.getUniqueId().toString(),null);}
     public Viewer get(Player p) {
         return get(p.getUniqueId().toString());
     }
+
     public Player get(Viewer viewer) {
         return Bukkit.getServer().getPlayer(UUID.fromString(viewer.getId()));
     }
@@ -139,6 +143,5 @@ public class ViewerManager extends Manager<Viewer> {
         cm.viewCameraInstant(cam, p);
         viewer.setCamera(cam);
     }
-
 
 }

--- a/src/main/java/io/github/tanguygab/cctv/managers/ViewerManager.java
+++ b/src/main/java/io/github/tanguygab/cctv/managers/ViewerManager.java
@@ -8,7 +8,6 @@ import io.github.tanguygab.cctv.menus.CCTVMenu;
 import io.github.tanguygab.cctv.menus.ViewerOptionsMenu;
 import io.github.tanguygab.cctv.utils.Heads;
 import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -53,12 +52,8 @@ public class ViewerManager extends Manager<Viewer> {
         Player p = get(viewer);
         p.getInventory().setContents(viewer.getInv());
 
-        p.removePotionEffect(PotionEffectType.NIGHT_VISION);
-        p.removePotionEffect(PotionEffectType.INVISIBILITY);
         p.removePotionEffect(PotionEffectType.SLOW);
-        playerSetMode(p,false, viewer.getGameMode());
-        for (Player online : Bukkit.getOnlinePlayers()) online.showPlayer(cctv,p);
-        p.teleport(viewer.getLoc());
+        p.setCanPickupItems(true);
         delete(id);
     }
 
@@ -74,22 +69,11 @@ public class ViewerManager extends Manager<Viewer> {
         return exists(p.getUniqueId().toString());
     }
 
-    private static void playerSetMode(Player p, boolean mode, GameMode gm) {
-        p.setCanPickupItems(!mode);
-        p.setGameMode(gm);
-        if (gm != GameMode.CREATIVE && gm != GameMode.SPECTATOR) {
-            p.setAllowFlight(mode);
-            p.setFlying(mode);
-        }
-        p.setCollidable(!mode);
-        p.setInvulnerable(mode);
-    }
-
     public void createPlayer(Player p, Camera cam, CameraGroup group) {
         Viewer viewer = new Viewer(p,cam,group);
         map.put(viewer.getId(),viewer);
 
-        playerSetMode(p,true, GameMode.ADVENTURE);
+        p.setCanPickupItems(false);
         giveViewerItems(p,group);
 
         for (Player online : Bukkit.getOnlinePlayers()) online.hidePlayer(cctv,p);

--- a/src/main/java/io/github/tanguygab/cctv/menus/ViewerOptionsMenu.java
+++ b/src/main/java/io/github/tanguygab/cctv/menus/ViewerOptionsMenu.java
@@ -1,5 +1,6 @@
 package io.github.tanguygab.cctv.menus;
 
+import io.github.tanguygab.cctv.entities.Viewer;
 import io.github.tanguygab.cctv.managers.ViewerManager;
 import io.github.tanguygab.cctv.utils.Heads;
 import io.github.tanguygab.cctv.utils.NMSUtils;
@@ -25,7 +26,7 @@ public class ViewerOptionsMenu extends CCTVMenu {
     @Override
     public void open() {
         inv = Bukkit.getServer().createInventory(null, 9, lang.CAMERA_VIEW_OPTIONS_TITLE);
-        if (hasItemPerm(p,"nightvision")) inv.setItem(3, p.hasPotionEffect(PotionEffectType.NIGHT_VISION) ? Heads.NIGHT_VISION_ON.get() : Heads.NIGHT_VISION_OFF.get());
+        if (hasItemPerm(p,"nightvision")) inv.setItem(3, vm.get(p).hasNightVision() ? Heads.NIGHT_VISION_ON.get() : Heads.NIGHT_VISION_OFF.get());
 
         if (hasItemPerm(p,"zoom")) {
             PotionEffect effect = p.getPotionEffect(PotionEffectType.SLOW);
@@ -49,7 +50,7 @@ public class ViewerOptionsMenu extends CCTVMenu {
     @Override
     public void onClick(ItemStack item, int slot, ClickType click) {
         switch (slot) {
-            case 3 -> nightvision(p, !p.hasPotionEffect(PotionEffectType.NIGHT_VISION));
+            case 3 -> nightvision(p);
             case 4 -> {
                 PotionEffect effect = p.getPotionEffect(PotionEffectType.SLOW);
                 if (effect == null) {
@@ -83,19 +84,15 @@ public class ViewerOptionsMenu extends CCTVMenu {
         NMSUtils.glow(viewer,viewed,glow);
         return true;
     }
-    private void nightvision(Player p, boolean vision) {
+    private void nightvision(Player p) {
         if (!p.hasPermission("cctv.view.nightvision")) {
             p.sendMessage(lang.NO_PERMISSIONS);
             return;
         }
         Inventory inv = p.getOpenInventory().getTopInventory();
-        if (vision) {
-            p.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, 60000000, 0, false, false));
-            inv.setItem(3, Heads.NIGHT_VISION_ON.get());
-            return;
-        }
-        p.removePotionEffect(PotionEffectType.NIGHT_VISION);
-        inv.setItem(3, Heads.NIGHT_VISION_OFF.get());
+        Viewer v = vm.get(p);
+        v.setNightVision(!v.hasNightVision());
+        inv.setItem(3, v.hasNightVision() ? Heads.NIGHT_VISION_ON.get() : Heads.NIGHT_VISION_OFF.get());
     }
     private void zoom(Player p, int zoomlevel) {
         if (!p.hasPermission("cctv.view.zoom")) {

--- a/src/main/java/io/github/tanguygab/cctv/menus/ViewerOptionsMenu.java
+++ b/src/main/java/io/github/tanguygab/cctv/menus/ViewerOptionsMenu.java
@@ -1,9 +1,9 @@
 package io.github.tanguygab.cctv.menus;
 
+import io.github.tanguygab.cctv.CCTV;
 import io.github.tanguygab.cctv.entities.Viewer;
 import io.github.tanguygab.cctv.managers.ViewerManager;
 import io.github.tanguygab.cctv.utils.Heads;
-import io.github.tanguygab.cctv.utils.NMSUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
@@ -17,6 +17,7 @@ import java.util.List;
 
 public class ViewerOptionsMenu extends CCTVMenu {
 
+    private final boolean oldCam = CCTV.get().getCameras().OLD_CAMERA_VIEW;
     private final ViewerManager vm = cctv.getViewers();
 
     public ViewerOptionsMenu(Player p) {
@@ -29,12 +30,14 @@ public class ViewerOptionsMenu extends CCTVMenu {
         if (hasItemPerm(p,"nightvision")) inv.setItem(3, vm.get(p).hasNightVision() ? Heads.NIGHT_VISION_ON.get() : Heads.NIGHT_VISION_OFF.get());
 
         if (hasItemPerm(p,"zoom")) {
-            PotionEffect effect = p.getPotionEffect(PotionEffectType.SLOW);
-            inv.setItem(4, getItem(Heads.ZOOM,
-                    effect != null
-                            ? lang.getCameraViewZoom(effect.getAmplifier()+1)
-                            : lang.CAMERA_VIEW_OPTIONS_ZOOM_OFF
-            ));
+            if (oldCam) {
+                PotionEffect effect = p.getPotionEffect(PotionEffectType.SLOW);
+                inv.setItem(4, getItem(Heads.ZOOM,
+                        effect != null
+                                ? lang.getCameraViewZoom(effect.getAmplifier() + 1)
+                                : lang.CAMERA_VIEW_OPTIONS_ZOOM_OFF
+                ));
+            } else inv.setItem(4,getItem(Heads.ZOOM,"&6Change your FOV!"));
         }
 
         if (hasItemPerm(p,"spot")) inv.setItem(5, getItem(Heads.SPOTTING,lang.CAMERA_VIEW_OPTIONS_SPOT));
@@ -52,6 +55,7 @@ public class ViewerOptionsMenu extends CCTVMenu {
         switch (slot) {
             case 3 -> nightvision(p);
             case 4 -> {
+                if (!oldCam) return;
                 PotionEffect effect = p.getPotionEffect(PotionEffectType.SLOW);
                 if (effect == null) {
                     zoom(p, 1);

--- a/src/main/java/io/github/tanguygab/cctv/menus/ViewerOptionsMenu.java
+++ b/src/main/java/io/github/tanguygab/cctv/menus/ViewerOptionsMenu.java
@@ -81,7 +81,7 @@ public class ViewerOptionsMenu extends CCTVMenu {
     }
     private boolean spot(Player viewer, Player viewed, boolean glow) {
         if (!viewed.canSee(viewed)) return false;
-        NMSUtils.glow(viewer,viewed,glow);
+        cctv.getNMS().glow(viewer,viewed,glow);
         return true;
     }
     private void nightvision(Player p) {

--- a/src/main/java/io/github/tanguygab/cctv/utils/NMSUtils.java
+++ b/src/main/java/io/github/tanguygab/cctv/utils/NMSUtils.java
@@ -1,21 +1,15 @@
 package io.github.tanguygab.cctv.utils;
 
-import com.mojang.authlib.GameProfile;
-import io.github.tanguygab.cctv.CCTV;
-import io.github.tanguygab.cctv.entities.Viewer;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.PacketPlayOutCamera;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityMetadata;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftEntity;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.game.*;
 import net.minecraft.server.level.EntityPlayer;
-import net.minecraft.world.level.World;
-import org.bukkit.craftbukkit.v1_18_R2.CraftServer;
-import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftPlayer;
+
 
 public class NMSUtils {
 
@@ -24,72 +18,17 @@ public class NMSUtils {
     }
 
     public static void glow(Player viewer, Player viewed, boolean glow) {
-        try {
-            EntityPlayer viewedNMS = ((CraftPlayer) viewed).getHandle();
-            viewedNMS.i(glow); //setGlowingTag(boolean)
-            if (!glow) {
-                viewed.setSneaking(true); // yeah, I'm doing that because it doesn't want to work with PacketPlayOutEntityMetadata...
-                viewed.setSneaking(false);
-            }
-            sendPacket(viewer,new PacketPlayOutEntityMetadata(viewedNMS.ae(), viewedNMS.ai(), true));
-        } catch (Exception e) {
-            // unsupported version
+        EntityPlayer viewedNMS = ((CraftPlayer) viewed).getHandle();
+        viewedNMS.i(glow); //setGlowingTag(boolean)
+        if (!glow) {
+            viewed.setSneaking(true); // yeah, I'm doing that because it doesn't want to work with PacketPlayOutEntityMetadata...
+            viewed.setSneaking(false);
         }
-    }
-
-    public static void spawnNPC(Player player, Location loc) {
-        try {
-            World world = ((CraftWorld)loc.getWorld()).getHandle();
-            CraftServer server = (CraftServer) Bukkit.getServer();
-            GameProfile profile = ((CraftPlayer)player).getProfile();
-            EntityPlayer npc = new EntityPlayer(server.getServer(),world.getMinecraftWorld(),profile);
-
-            npc.a(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
-            Viewer p = CCTV.get().getViewers().get(player);
-            p.setNpc(npc);
-            for (Player online : Bukkit.getOnlinePlayers()) spawnNPCForTarget(online, player);
-        } catch (Exception e) {
-            // unsupported version
-        }
-    }
-
-    public static void despawnNPC(Player p, Viewer viewer) {
-        try {
-            EntityPlayer npc = (EntityPlayer) viewer.getNpc();
-            PacketPlayOutEntityDestroy packet = (PacketPlayOutEntityDestroy) Class.forName("net.minecraft.network.protocol.game.PacketPlayOutEntityDestroy")
-                    .getConstructor(int[].class)
-                    .newInstance(new int[]{npc.ae()});
-
-            for (Player online : Bukkit.getOnlinePlayers()) {
-                if (p == online) continue;
-                sendPacket(online,packet);
-                online.showPlayer(CCTV.get(),p);
-            }
-        } catch (Exception e) {
-            // unsupported version
-        }
-    }
-
-    public static void spawnNPCForTarget(Player player, Player target) {
-        if (player == target) return;
-        try {
-            Viewer p = CCTV.get().getViewers().get(target);
-            EntityPlayer npc = (EntityPlayer) p.getNpc();
-            sendPacket(player,new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.a, npc));
-            sendPacket(player,new PacketPlayOutNamedEntitySpawn(npc));
-            sendPacket(player,new PacketPlayOutEntityHeadRotation(npc, (byte) (int) (p.getLoc().getYaw() * 256.0F / 360.0F)));
-        } catch (Exception e) {
-            // unsupported version
-        }
+        sendPacket(viewer,new PacketPlayOutEntityMetadata(viewedNMS.ae(), viewedNMS.ai(), true));
     }
 
     public static void setCameraPacket(Player p, Entity entity) {
-        try {
-            sendPacket(p,new PacketPlayOutCamera(((CraftEntity)entity).getHandle()));
-        } catch (Exception e) {
-            p.sendMessage("oops");
-            // unsupported version
-        }
+        sendPacket(p,new PacketPlayOutCamera(((CraftEntity)entity).getHandle()));
     }
 
 }

--- a/src/main/java/io/github/tanguygab/cctv/utils/NMSUtils.java
+++ b/src/main/java/io/github/tanguygab/cctv/utils/NMSUtils.java
@@ -5,6 +5,8 @@ import io.github.tanguygab.cctv.CCTV;
 import io.github.tanguygab.cctv.entities.Viewer;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_18_R2.entity.CraftEntity;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 import net.minecraft.network.protocol.Packet;
@@ -77,6 +79,15 @@ public class NMSUtils {
             sendPacket(player,new PacketPlayOutNamedEntitySpawn(npc));
             sendPacket(player,new PacketPlayOutEntityHeadRotation(npc, (byte) (int) (p.getLoc().getYaw() * 256.0F / 360.0F)));
         } catch (Exception e) {
+            // unsupported version
+        }
+    }
+
+    public static void setCameraPacket(Player p, Entity entity) {
+        try {
+            sendPacket(p,new PacketPlayOutCamera(((CraftEntity)entity).getHandle()));
+        } catch (Exception e) {
+            p.sendMessage("oops");
             // unsupported version
         }
     }

--- a/src/main/java/io/github/tanguygab/cctv/utils/NMSUtils.java
+++ b/src/main/java/io/github/tanguygab/cctv/utils/NMSUtils.java
@@ -1,6 +1,8 @@
 package io.github.tanguygab.cctv.utils;
 
+import io.github.tanguygab.cctv.CCTV;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
@@ -8,6 +10,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 
 
 public class NMSUtils {
@@ -87,7 +91,26 @@ public class NMSUtils {
         }
     }
 
+    private final Map<Player, Location> oldLoc = new HashMap<>();
+
     public void setCameraPacket(Player p, Entity entity) {
+        if (CCTV.get().getCameras().OLD_CAMERA_VIEW) {
+            boolean view = p != entity;
+            Location loc = oldLoc.get(p);
+            if (view) {
+                oldLoc.putIfAbsent(p,p.getLocation());
+                loc = entity.getLocation().clone();
+                loc.add(0,1,0);
+            }
+            else oldLoc.remove(p);
+            p.teleport(loc);
+            p.setInvisible(view);
+            p.setAllowFlight(view);
+            p.setInvulnerable(view);
+            p.setCollidable(!view);
+            p.setGravity(!view);
+            return;
+        }
         try {
             Object nmsEntity = getEntityHandle.invoke(entity);
             sendPacket(p,newPacketPlayOutCameraClass.newInstance(nmsEntity));


### PR DESCRIPTION
Uisng the Camera packet to view a camera instead of teleporting thet player and creating an NPC.
Also added a config option to use the old teleportation method, but no NPCs.
This also uses reflection for multi-version support.